### PR TITLE
Remove condition

### DIFF
--- a/src/WebApi/WebApi/Modules/SwaggerExtension.cs
+++ b/src/WebApi/WebApi/Modules/SwaggerExtension.cs
@@ -34,15 +34,8 @@ public static class SwaggerExtension
             {
                 foreach (ApiVersionDescription description in provider.ApiVersionDescriptions)
                 {
-                    if (env.IsDevelopment() || env.IsEnvironment("local"))
-                    {
-                        options.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json",
-                            description.GroupName.ToUpperInvariant());
-                    }
-                    else
-                    {
-                        options.SwaggerEndpoint($"/accounts-api/swagger/{description.GroupName}/swagger.json", "Accounts-API Reverse proxy");
-                    }
+                    options.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json",
+                        description.GroupName.ToUpperInvariant());
                 }
             });
 


### PR DESCRIPTION
We don't have a reverse proxy so far, which means only the option currently in the first block of the condition should be used.