### PR TITLE
Technical debt/GitHub warnings

### DIFF
--- a/src/WebApi/Application/Repositories/IGenericRepository.cs
+++ b/src/WebApi/Application/Repositories/IGenericRepository.cs
@@ -7,13 +7,13 @@ public interface IGenericRepository<TModel, TEntity>
 {
     Task<IEnumerable<TModel>> GetAll();
 
-    Task<TModel> GetById(params object[] key);
+    Task<TModel> GetById(params object[] id);
 
-    Task<TModel> Create(TModel entity);
+    Task<TModel> Create(TModel model);
 
-    Task<bool> BulkCreate(IEnumerable<TModel> entity);
+    Task<bool> BulkCreate(IEnumerable<TModel> model);
 
-    Task<bool> Update(TModel entity);
+    Task<bool> Update(TModel model);
 
-    Task<bool> Delete(params object[] key);
+    Task<bool> Delete(params object[] id);
 }

--- a/src/WebApi/Application/Repositories/IQuestionSetRepository.cs
+++ b/src/WebApi/Application/Repositories/IQuestionSetRepository.cs
@@ -7,7 +7,7 @@ namespace Application.Repositories;
 
 public interface IQuestionSetRepository : IGenericRepository<QuestionSetModel, IEntity>
 {
-    Task<bool> AddQuestionsToList(int questionSetId, IEnumerable<int> questionIds);
+    Task<bool> AddQuestionsToList(int questionListId, IEnumerable<int> interviewQuestionIds);
 
-    Task<bool> RemoveQuestionsFromList(int questionSetId, IEnumerable<int> questionIds);
+    Task<bool> RemoveQuestionsFromList(int questionListId, IEnumerable<int> interviewQuestionIds);
 }

--- a/src/WebApi/Application/UseCases/QuestionSet/CreateQuestionSet/CreateQuestionSetUseCase.cs
+++ b/src/WebApi/Application/UseCases/QuestionSet/CreateQuestionSet/CreateQuestionSetUseCase.cs
@@ -16,14 +16,14 @@ public class CreateQuestionSetUseCase : ICreateQuestionSetUseCase
         _questionSetRepository = questionSetRepository;
     }
 
-    public async Task Execute(CreateQuestionSetInput input)
+    public Task Execute(CreateQuestionSetInput input)
     {
         if (input.Title is null)
         {
             throw new ArgumentException("Please provide a title for a new question list!", nameof(input));
         }
 
-        await CreateQuestionSetInternal(input);
+        return CreateQuestionSetInternal(input);
     }
 
     public void SetOutputPort(IOutputPort outputPort) => _outputPort = outputPort;

--- a/src/WebApi/Domain/Exceptions/DomainException.cs
+++ b/src/WebApi/Domain/Exceptions/DomainException.cs
@@ -2,6 +2,7 @@
 
 namespace Domain.Exceptions;
 
+[Serializable]
 public abstract class DomainException : Exception
 {
     protected DomainException(string message) : base(message)

--- a/src/WebApi/Domain/Exceptions/DomainException.cs
+++ b/src/WebApi/Domain/Exceptions/DomainException.cs
@@ -1,11 +1,16 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace Domain.Exceptions;
 
 [Serializable]
 public abstract class DomainException : Exception
 {
-    protected DomainException(string message) : base(message)
-    {
-    }
+    protected DomainException() { }
+
+    protected DomainException(string message) : base(message) { }
+
+    protected DomainException(string message, Exception inner) : base(message, inner) { }
+
+    protected DomainException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 }

--- a/src/WebApi/Domain/Exceptions/DomainException.cs
+++ b/src/WebApi/Domain/Exceptions/DomainException.cs
@@ -4,5 +4,7 @@ namespace Domain.Exceptions;
 
 public abstract class DomainException : Exception
 {
-    public DomainException(string message) : base(message) {}
+    protected DomainException(string message) : base(message)
+    {
+    }
 }

--- a/src/WebApi/Infrastructure/Repositories/GenericRepository.cs
+++ b/src/WebApi/Infrastructure/Repositories/GenericRepository.cs
@@ -99,9 +99,9 @@ public abstract class GenericRepository<TModel, TEntity> : IGenericRepository<TM
         return models;
     }
 
-    public async Task<TModel> GetById(params object[] key)
+    public async Task<TModel> GetById(params object[] id)
     {
-        var entity = await DbContext.Set<TEntity>().FindAsync(key);
+        var entity = await DbContext.Set<TEntity>().FindAsync(id);
         if (entity != null)
             DbContext.Entry<TEntity>(entity).State = EntityState.Detached;
 

--- a/src/WebApi/Infrastructure/Repositories/GenericRepository.cs
+++ b/src/WebApi/Infrastructure/Repositories/GenericRepository.cs
@@ -14,7 +14,7 @@ public abstract class GenericRepository<TModel, TEntity> : IGenericRepository<TM
     protected IMapper _mapper;
     protected MyDbContext DbContext { get; }
 
-    public GenericRepository(MyDbContext dbContext, IMapper mapper)
+    protected GenericRepository(MyDbContext dbContext, IMapper mapper)
     {
         DbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));

--- a/src/WebApi/Infrastructure/Repositories/GenericRepository.cs
+++ b/src/WebApi/Infrastructure/Repositories/GenericRepository.cs
@@ -20,21 +20,21 @@ public abstract class GenericRepository<TModel, TEntity> : IGenericRepository<TM
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
 
-    public async Task<TModel> Create(TModel entity)
+    public async Task<TModel> Create(TModel model)
     {
-        var toCreate = _mapper.Map<TEntity>(entity);
+        var entity = _mapper.Map<TEntity>(model);
 
         DateTime now = DateTime.Now;
-        toCreate.CreatedAt = now;
-        toCreate.UpdatedAt = now;
+        entity.CreatedAt = now;
+        entity.UpdatedAt = now;
 
-        await DbContext.Set<TEntity>().AddAsync(toCreate);
+        await DbContext.Set<TEntity>().AddAsync(entity);
 
         try
         {
             var result = await DbContext.SaveChangesAsync();
-            DbContext.Entry(toCreate).State = EntityState.Detached;
-            return result > 0 ? _mapper.Map<TModel>(toCreate) : null;
+            DbContext.Entry(entity).State = EntityState.Detached;
+            return result > 0 ? _mapper.Map<TModel>(entity) : null;
         }
         catch (DbUpdateException)
         {

--- a/src/WebApi/Infrastructure/Repositories/GenericRepository.cs
+++ b/src/WebApi/Infrastructure/Repositories/GenericRepository.cs
@@ -20,21 +20,21 @@ public abstract class GenericRepository<TModel, TEntity> : IGenericRepository<TM
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
 
-    public async Task<TModel> Create(TModel model)
+    public async Task<TModel> Create(TModel entity)
     {
-        var entity = _mapper.Map<TEntity>(model);
+        var toCreate = _mapper.Map<TEntity>(entity);
 
         DateTime now = DateTime.Now;
-        entity.CreatedAt = now;
-        entity.UpdatedAt = now;
+        toCreate.CreatedAt = now;
+        toCreate.UpdatedAt = now;
 
-        await DbContext.Set<TEntity>().AddAsync(entity);
+        await DbContext.Set<TEntity>().AddAsync(toCreate);
 
         try
         {
             var result = await DbContext.SaveChangesAsync();
-            DbContext.Entry(entity).State = EntityState.Detached;
-            return result > 0 ? _mapper.Map<TModel>(entity) : null;
+            DbContext.Entry(toCreate).State = EntityState.Detached;
+            return result > 0 ? _mapper.Map<TModel>(toCreate) : null;
         }
         catch (DbUpdateException)
         {

--- a/src/WebApi/UnitTests/Tests/Application/Exceptions/DomainExceptionTest.cs
+++ b/src/WebApi/UnitTests/Tests/Application/Exceptions/DomainExceptionTest.cs
@@ -1,0 +1,28 @@
+﻿using Domain.Exceptions;
+using System;
+using System.Runtime.Serialization;
+using Xunit;
+
+namespace UnitTests.Tests.Application.Exceptions;    
+
+public class DomainExceptionTest
+{
+    private sealed class InstantiableDomainException : DomainException
+    {
+        public InstantiableDomainException() { }
+
+        public InstantiableDomainException(string message) : base(message) { }
+
+        public InstantiableDomainException(string message, Exception inner) : base(message, inner) { }
+
+        public InstantiableDomainException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+
+    [Fact]
+    public void DomainException_CanBeThrown()
+    {
+        static void Throw() => throw new InstantiableDomainException("Test message");
+
+        Assert.ThrowsAny<DomainException>(Throw);
+    }
+}

--- a/src/WebApi/UnitTests/Tests/Application/Exceptions/DomainExceptionTest.cs
+++ b/src/WebApi/UnitTests/Tests/Application/Exceptions/DomainExceptionTest.cs
@@ -14,8 +14,6 @@ public class DomainExceptionTest
         public InstantiableDomainException(string message) : base(message) { }
 
         public InstantiableDomainException(string message, Exception inner) : base(message, inner) { }
-
-        public InstantiableDomainException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
     [Fact]
@@ -24,11 +22,9 @@ public class DomainExceptionTest
         static void ThrowFirstConstructor() => throw new InstantiableDomainException();
         static void ThrowSecondConstructor() => throw new InstantiableDomainException("Test message");
         static void ThrowThirdConstructor() => throw new InstantiableDomainException("Test message", new InstantiableDomainException());
-        static void ThrowFourthConstructor() => throw new InstantiableDomainException(null, new StreamingContext(StreamingContextStates.All));
 
         Assert.ThrowsAny<DomainException>(ThrowFirstConstructor);
         Assert.ThrowsAny<DomainException>(ThrowSecondConstructor);
         Assert.ThrowsAny<DomainException>(ThrowThirdConstructor);
-        Assert.ThrowsAny<DomainException>(ThrowFourthConstructor);
     }
 }

--- a/src/WebApi/UnitTests/Tests/Application/Exceptions/DomainExceptionTest.cs
+++ b/src/WebApi/UnitTests/Tests/Application/Exceptions/DomainExceptionTest.cs
@@ -21,8 +21,14 @@ public class DomainExceptionTest
     [Fact]
     public void DomainException_CanBeThrown()
     {
-        static void Throw() => throw new InstantiableDomainException("Test message");
+        static void ThrowFirstConstructor() => throw new InstantiableDomainException();
+        static void ThrowSecondConstructor() => throw new InstantiableDomainException("Test message");
+        static void ThrowThirdConstructor() => throw new InstantiableDomainException("Test message", new InstantiableDomainException());
+        static void ThrowFourthConstructor() => throw new InstantiableDomainException(null, null);
 
-        Assert.ThrowsAny<DomainException>(Throw);
+        Assert.ThrowsAny<DomainException>(ThrowFirstConstructor);
+        Assert.ThrowsAny<DomainException>(ThrowSecondConstructor);
+        Assert.ThrowsAny<DomainException>(ThrowThirdConstructor);
+        Assert.ThrowsAny<DomainException>(ThrowFourthConstructor);
     }
 }

--- a/src/WebApi/UnitTests/Tests/Application/Exceptions/DomainExceptionTest.cs
+++ b/src/WebApi/UnitTests/Tests/Application/Exceptions/DomainExceptionTest.cs
@@ -24,7 +24,7 @@ public class DomainExceptionTest
         static void ThrowFirstConstructor() => throw new InstantiableDomainException();
         static void ThrowSecondConstructor() => throw new InstantiableDomainException("Test message");
         static void ThrowThirdConstructor() => throw new InstantiableDomainException("Test message", new InstantiableDomainException());
-        static void ThrowFourthConstructor() => throw new InstantiableDomainException(null, null);
+        static void ThrowFourthConstructor() => throw new InstantiableDomainException(null, new StreamingContext(StreamingContextStates.All));
 
         Assert.ThrowsAny<DomainException>(ThrowFirstConstructor);
         Assert.ThrowsAny<DomainException>(ThrowSecondConstructor);

--- a/src/WebApi/WebApi/Modules/SwaggerExtension.cs
+++ b/src/WebApi/WebApi/Modules/SwaggerExtension.cs
@@ -3,8 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-
+using System.Linq;
 
 namespace WebApi.Modules;
 
@@ -32,10 +31,10 @@ public static class SwaggerExtension
         app.UseSwaggerUI(
             options =>
             {
-                foreach (ApiVersionDescription description in provider.ApiVersionDescriptions)
+                foreach (string groupName in provider.ApiVersionDescriptions.Select(description => description.GroupName))
                 {
-                    options.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json",
-                        description.GroupName.ToUpperInvariant());
+                    options.SwaggerEndpoint($"/swagger/{groupName}/swagger.json",
+                        groupName.ToUpperInvariant());
                 }
             });
 


### PR DESCRIPTION
## Summary

Fixing github warning shown with every pull requests. One waning cannot be fixed in code and that is [Configuring loggers is security-sensitive](https://jira.sonarsource.com/browse/RSPEC-4792). The rule basically says that we should double check to make sure our logger configuration is correct and we are logging correct stuff in case of a potential attack on the system. 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactoring (non-breaking change to code and structure)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

