### PR TITLE
Add Code Standrads through .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,233 @@
+###############################
+# Core EditorConfig Options   #
+###############################
+root = true
+
+[*]
+indent_style = space
+
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+###############################
+# C# / .NET Specific options  #
+###############################
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+
+[*.{cs,vb}]
+dotnet_sort_system_directives_first = true
+
+csharp_using_directive_placement = inside_namespace:warning
+
+# this. preferences
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+dotnet_style_readonly_field = true:warning
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = false:suggestion
+
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# Use PascalCase for constant fields  
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+
+# diagnostic
+dotnet_diagnostic.CA1825.severity = warning
+## simplify names
+dotnet_diagnostic.IDE0001.severity = warning
+dotnet_diagnostic.IDE0002.severity = warning
+## no unnecessary cast
+dotnet_diagnostic.IDE0004.severity = warning
+dotnet_diagnostic.IDE0005.severity = warning
+## missing cases in switches / switch expressions
+dotnet_diagnostic.IDE0010.severity = warning
+dotnet_diagnostic.IDE0072.severity = warning
+## remove unreachable code
+dotnet_diagnostic.IDE0035.severity = warning
+## remove unused private members
+dotnet_diagnostic.IDE0051.severity = warning
+dotnet_diagnostic.IDE0052.severity = warning
+## fix formatting
+dotnet_diagnostic.IDE0055.severity = warning
+## remove unnecessary supression operator
+dotnet_diagnostic.IDE0080.severity = warning
+## convert typeof to nameof
+dotnet_diagnostic.IDE0082.severity = warning
+## remove unnecessary equality operator
+dotnet_diagnostic.IDE0100.severity = warning
+## remove unnecessary discard
+dotnet_diagnostic.IDE0110.severity = warning
+## avoid out parameters
+dotnet_diagnostic.CA1021.severity = warning
+## use properties where appropriate
+dotnet_diagnostic.CA1024.severity = warning
+## avoid empty interfaces
+dotnet_diagnostic.CA1040.severity = warning
+## declare types in namespaces
+dotnet_diagnostic.CA1050.severity = error
+## do not declare visible instance fields
+dotnet_diagnostic.CA1051.severity = warning
+## implement IDisposable correctly
+dotnet_diagnostic.CA1063.severity = warning
+## enums should not have duplicate values
+dotnet_diagnostic.CA1069.severity = warning
+## avoid excessive inheritance
+dotnet_diagnostic.CA1501.severity = suggestion
+## avoid excessive complexity
+dotnet_diagnostic.CA1502.severity = warning
+## avoid unmaintainable code
+dotnet_diagnostic.CA1505.severity = warning
+## avoid excessive class coupling
+dotnet_diagnostic.CA1506.severity = warning
+## use nameof instead of string literal
+dotnet_diagnostic.CA1507.severity = warning
+## avoid dead conditional code
+dotnet_diagnostic.CA1508.severity = error
+## identifiers should have correct prefix
+dotnet_diagnostic.CA1715.severity = warning
+## identifiers should not match keywords
+dotnet_diagnostic.CA1716.severity = warning
+## identifiers should not cointain type names
+dotnet_diagnostic.CA1720.severity = suggestion
+## property names should not match get methods
+dotnet_diagnostic.CA1721.severity = warning
+## review unused parameters
+dotnet_diagnostic.CA1801.severity = warning
+## identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1711.severity = warning
+## identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = suggestion
+## identifiers should differ by more than case
+dotnet_diagnostic.CA1708.severity = warning
+## call async methods when in an async method
+dotnet_diagnostic.CA1849.severity = suggestion
+## possible multiple enumerations of IEnumerable
+dotnet_diagnostic.CA1851.severity = warning
+## dispose objects before losing scope
+dotnet_diagnostic.CA2000.severity = warning
+## parameter count mismatch
+dotnet_diagnostic.CA2017.severity = suggestion
+## do not assign a property to itself
+dotnet_diagnostic.CA2245.severity = error
+## review code for file path injection vulnerabilities
+dotnet_diagnostic.CA3003.severity = suggestion
+## do not hard-code encryption key
+dotnet_diagnostic.CA5390.severity = error
+## do not hard-code certificate
+dotnet_diagnostic.CA5403.severity = error
+## use literals where appropriate
+dotnet_diagnostic.CA1802.severity = warning
+## do not initialize unnecessarily
+dotnet_diagnostic.CA1805.severity = warning
+## test for empty string using string length
+dotnet_diagnostic.CA1820.severity = warning
+## remove empty finalizers
+dotnet_diagnostic.CA1821.severity = warning
+## avoid unused private fields
+dotnet_diagnostic.CA1823.severity = warning
+## avoid IsEmpty over Count when available
+dotnet_diagnostic.CA1836.severity = warning
+
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:silent
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:suggestion
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+
+# Expression-level preferences
+csharp_prefer_braces = false:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+
+[*.vb]
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion


### PR DESCRIPTION
## Summary

Added a `.editorconfig` file with specific rules for .NET and C#. Some of these rules are fairly strict and will require either softening through setting the severity to `suggestion` or deletion altogether.

@ maintainers, feel free to commit changed into this PR.

We should hopefully see the warnings introduced in the CI/CD pipeline, if not, feel free to checkout and build the branch. By default, these warnings should show in your Visual Studio Output window (or CLI for the first build). Some are suggestions and will be only visible in the appropriate files through the IDE.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (non-breaking change to code and structure)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notes

The .editorconfig should be annotated, so feel free to search for a specific warning by what it actually says. You can also search by the Code (ie. `CA1716`)

Co-assigning @PlesnikJakub since we discussed some of these changes together. ☺️ 
