### PR TITLE
Refactor/e2e tests

### DIFF
--- a/src/WebApi/End2endTests/HttpWrapper.cs
+++ b/src/WebApi/End2endTests/HttpWrapper.cs
@@ -48,11 +48,11 @@ public class HttpWrapper
         return new StandardResponse<U>(response);
     }
 
-    public async Task<StandardResponse<T>> DeleteAsync<T>(string url, NameValueCollection queryParams = null)
+    public async Task<StandardResponse> DeleteAsync<T>(string url, NameValueCollection queryParams = null)
     {
         string getUrl = HttpHelpers.CreateQueryString(url, queryParams);
         HttpResponseMessage response = await _client.DeleteAsync(getUrl);
-        return new StandardResponse<T>(response);
+        return new StandardResponse(response);
     }
 }
 

--- a/src/WebApi/End2endTests/HttpWrapper.cs
+++ b/src/WebApi/End2endTests/HttpWrapper.cs
@@ -22,28 +22,28 @@ public class HttpWrapper
 
     public async Task<StandardResponse> PostAsync<TRequest>(string url, TRequest payload)
     {
-        var json = HttpHelpers.CreateBodyContent(payload);
+        using var json = HttpHelpers.CreateBodyContent(payload);
         HttpResponseMessage response = await _client.PostAsync(url, json);
         return new StandardResponse(response);
     }
 
     public async Task<StandardResponse<TResponse>> PostAsync<TRequest, TResponse>(string url, TRequest payload)
     {
-        var json = HttpHelpers.CreateBodyContent(payload);
+        using var json = HttpHelpers.CreateBodyContent(payload);
         HttpResponseMessage response = await _client.PostAsync(url, json);
         return new StandardResponse<TResponse>(response);
     }
 
     public async Task<StandardResponse> PutAsync<TRequest>(string url, TRequest payload)
     {
-        var json = HttpHelpers.CreateBodyContent(payload);
+        using var json = HttpHelpers.CreateBodyContent(payload);
         HttpResponseMessage response = await _client.PutAsync(url, json);
         return new StandardResponse(response);
     }
 
     public async Task<StandardResponse<TResponse>> PutAsync<TRequest, TResponse>(string url, TRequest payload)
     {
-        var json = HttpHelpers.CreateBodyContent(payload);
+        using var json = HttpHelpers.CreateBodyContent(payload);
         HttpResponseMessage response = await _client.PutAsync(url, json);
         return new StandardResponse<TResponse>(response);
     }

--- a/src/WebApi/End2endTests/HttpWrapper.cs
+++ b/src/WebApi/End2endTests/HttpWrapper.cs
@@ -48,7 +48,7 @@ public class HttpWrapper
         return new StandardResponse<U>(response);
     }
 
-    public async Task<StandardResponse> DeleteAsync<T>(string url, NameValueCollection queryParams = null)
+    public async Task<StandardResponse> DeleteAsync(string url, NameValueCollection queryParams = null)
     {
         string getUrl = HttpHelpers.CreateQueryString(url, queryParams);
         HttpResponseMessage response = await _client.DeleteAsync(getUrl);

--- a/src/WebApi/End2endTests/HttpWrapper.cs
+++ b/src/WebApi/End2endTests/HttpWrapper.cs
@@ -13,39 +13,39 @@ public class HttpWrapper
         _client = client;
     }
 
-    public async Task<StandardResponse<T>> GetAsync<T>(string url, NameValueCollection queryParams = null)
+    public async Task<StandardResponse<TResponse>> GetAsync<TResponse>(string url, NameValueCollection queryParams = null)
     {
         string getUrl = HttpHelpers.CreateQueryString(url, queryParams);
         HttpResponseMessage response = await _client.GetAsync(getUrl);
-        return new StandardResponse<T>(response);
+        return new StandardResponse<TResponse>(response);
     }
 
-    public async Task<StandardResponse> PostAsync<T>(string url, T payload)
+    public async Task<StandardResponse> PostAsync<TRequest>(string url, TRequest payload)
     {
         var json = HttpHelpers.CreateBodyContent(payload);
         HttpResponseMessage response = await _client.PostAsync(url, json);
         return new StandardResponse(response);
     }
 
-    public async Task<StandardResponse<U>> PostAsync<T, U>(string url, T payload)
+    public async Task<StandardResponse<TResponse>> PostAsync<TRequest, TResponse>(string url, TRequest payload)
     {
         var json = HttpHelpers.CreateBodyContent(payload);
         HttpResponseMessage response = await _client.PostAsync(url, json);
-        return new StandardResponse<U>(response);
+        return new StandardResponse<TResponse>(response);
     }
 
-    public async Task<StandardResponse> PutAsync<T>(string url, T payload)
+    public async Task<StandardResponse> PutAsync<TRequest>(string url, TRequest payload)
     {
         var json = HttpHelpers.CreateBodyContent(payload);
         HttpResponseMessage response = await _client.PutAsync(url, json);
         return new StandardResponse(response);
     }
 
-    public async Task<StandardResponse<U>> PutAsync<T, U>(string url, T payload)
+    public async Task<StandardResponse<TResponse>> PutAsync<TRequest, TResponse>(string url, TRequest payload)
     {
         var json = HttpHelpers.CreateBodyContent(payload);
         HttpResponseMessage response = await _client.PutAsync(url, json);
-        return new StandardResponse<U>(response);
+        return new StandardResponse<TResponse>(response);
     }
 
     public async Task<StandardResponse> DeleteAsync(string url, NameValueCollection queryParams = null)

--- a/src/WebApi/End2endTests/QuestionSetTests/DeleteQuestionSetTests.cs
+++ b/src/WebApi/End2endTests/QuestionSetTests/DeleteQuestionSetTests.cs
@@ -15,7 +15,7 @@ public class DeleteQuestionSetTests : E2ETestsBase, IClassFixture<MyWebApplicati
     {
     }
 
-    private async Task<StandardResponse<QuestionSetModel>> EndpointCall(int id) => await _wrapper.DeleteAsync<QuestionSetModel>(_url(id));
+    private async Task<StandardResponse> EndpointCall(int id) => await _wrapper.DeleteAsync<QuestionSetModel>(_url(id));
 
     [Fact]
     public async Task Delete_ValidRequest_ReturnsNoContent()

--- a/src/WebApi/End2endTests/QuestionSetTests/DeleteQuestionSetTests.cs
+++ b/src/WebApi/End2endTests/QuestionSetTests/DeleteQuestionSetTests.cs
@@ -15,7 +15,7 @@ public class DeleteQuestionSetTests : E2ETestsBase, IClassFixture<MyWebApplicati
     {
     }
 
-    private async Task<StandardResponse> EndpointCall(int id) => await _wrapper.DeleteAsync<QuestionSetModel>(_url(id));
+    private async Task<StandardResponse> EndpointCall(int id) => await _wrapper.DeleteAsync(_url(id));
 
     [Fact]
     public async Task Delete_ValidRequest_ReturnsNoContent()

--- a/src/WebApi/End2endTests/QuestionTests/DeleteQuestionSet.cs
+++ b/src/WebApi/End2endTests/QuestionTests/DeleteQuestionSet.cs
@@ -15,7 +15,7 @@ public class DeleteQuestionTests : E2ETestsBase, IClassFixture<MyWebApplicationF
     {
     }
 
-    private async Task<StandardResponse> EndpointCall(int id) => await _wrapper.DeleteAsync<QuestionModel>(_url(id));
+    private async Task<StandardResponse> EndpointCall(int id) => await _wrapper.DeleteAsync(_url(id));
 
     [Fact]
     public async Task Create_ValidRequest_ReturnsNoContent()

--- a/src/WebApi/End2endTests/QuestionTests/DeleteQuestionSet.cs
+++ b/src/WebApi/End2endTests/QuestionTests/DeleteQuestionSet.cs
@@ -15,7 +15,7 @@ public class DeleteQuestionTests : E2ETestsBase, IClassFixture<MyWebApplicationF
     {
     }
 
-    private async Task<StandardResponse<QuestionModel>> EndpointCall(int id) => await _wrapper.DeleteAsync<QuestionModel>(_url(id));
+    private async Task<StandardResponse> EndpointCall(int id) => await _wrapper.DeleteAsync<QuestionModel>(_url(id));
 
     [Fact]
     public async Task Create_ValidRequest_ReturnsNoContent()


### PR DESCRIPTION
## Summary

Changed the generic parameters naming of `HttpWrapper` in E2E tests to be more clear, added usings to correctly dispose of network related resources. Fixes some of the errors that will be introduced by #86 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactoring (non-breaking change to code and structure)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

