### PR TITLE
API: Update difficulty attribute

### DIFF
--- a/src/WebApi/End2endTests/QuestionTests/UpdateQuestionTests.cs
+++ b/src/WebApi/End2endTests/QuestionTests/UpdateQuestionTests.cs
@@ -48,7 +48,7 @@ public class UpdateQuestionTests : E2ETestsBase, IClassFixture<MyWebApplicationF
     {
         var request = new UpdateQuestionRequest
         {
-            Difficulty = 6
+            Difficulty = 150
         };
 
         var result = await EndpointCall(1, request);

--- a/src/WebApi/WebApi/Extensions/RangeValidationAttributeExtension.cs
+++ b/src/WebApi/WebApi/Extensions/RangeValidationAttributeExtension.cs
@@ -19,11 +19,7 @@
         {
             if (value is IEnumerable<int> list && list.Count() > 0)
             {
-                if (list.Any(i => i < Min || i > Max))
-                {
-                    return false;
-                }
-                return true;
+                return !list.Any(i => i < Min || i > Max);
             }
 
             return true;

--- a/src/WebApi/WebApi/Extensions/RangeValidationAttributeExtension.cs
+++ b/src/WebApi/WebApi/Extensions/RangeValidationAttributeExtension.cs
@@ -17,7 +17,7 @@
 
         public override bool IsValid(object value)
         {
-            if (value is IEnumerable<int> list && list.Count() > 0)
+            if (value is IEnumerable<int> list && list.Any())
             {
                 return !list.Any(i => i < Min || i > Max);
             }

--- a/src/WebApi/WebApi/Extensions/RangeValidationAttributeExtension.cs
+++ b/src/WebApi/WebApi/Extensions/RangeValidationAttributeExtension.cs
@@ -1,0 +1,32 @@
+﻿namespace WebApi.Extensions
+{
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+
+    public class RangeValidationAttributeExtension : ValidationAttribute
+    {
+        public int Min { get; set; }
+        public int Max { get; set; }
+
+        public RangeValidationAttributeExtension()
+        {
+            Min = 0;
+            Max = int.MaxValue;
+        }
+
+        public override bool IsValid(object value)
+        {
+            if (value is IEnumerable<int> list && list.Count() > 0)
+            {
+                if (list.Any(i => i < Min || i > Max))
+                {
+                    return false;
+                }
+                return true;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/WebApi/WebApi/UseCases/v1/Question/CreateQuestion/CreateQuestionRequest.cs
+++ b/src/WebApi/WebApi/UseCases/v1/Question/CreateQuestion/CreateQuestionRequest.cs
@@ -10,7 +10,7 @@ public record CreateQuestionRequest
     public string Title { get; set; }
 
     [Range(0, 100, ErrorMessage = "The Difficulty field is out of range ( 0 - 100 )")]
-    [Required(ErrorMessage = "The Difficulty field is required.")]
+    [Required]
     public int? Difficulty { get; set; }
 
     [Required]

--- a/src/WebApi/WebApi/UseCases/v1/Question/CreateQuestion/CreateQuestionRequest.cs
+++ b/src/WebApi/WebApi/UseCases/v1/Question/CreateQuestion/CreateQuestionRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace WebApi.UseCases.v1.Question.CreateQuestion;
 
@@ -8,7 +9,8 @@ public record CreateQuestionRequest
     [MaxLength(100)]
     public string Title { get; set; }
 
-    [Range(1, 5)]
+    [Range(0, 100, ErrorMessage = "The Difficulty field is out of range ( 0 - 100 )")]
+    [Required(ErrorMessage = "The Difficulty field is required.")]
     public int? Difficulty { get; set; }
 
     [Required]

--- a/src/WebApi/WebApi/UseCases/v1/Question/GetQuestion/GetQuestionRequest.cs
+++ b/src/WebApi/WebApi/UseCases/v1/Question/GetQuestion/GetQuestionRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using WebApi.Extensions;
 
 namespace WebApi.UseCases.v1.Question.GetQuestion;
 
@@ -11,5 +12,6 @@ public record GetQuestionRequest
     [MaxLength(250)]
     public string Text { get; set; }
 
+    [RangeValidationAttributeExtension(Min = 0, Max = 100, ErrorMessage = "The Difficulty field is out of range ( 0 - 100 )")]
     public IEnumerable<int> Difficulties { get; set; }
 }

--- a/src/WebApi/WebApi/UseCases/v1/Question/UpdateQuestion/UpdateQuestionRequest.cs
+++ b/src/WebApi/WebApi/UseCases/v1/Question/UpdateQuestion/UpdateQuestionRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace WebApi.UseCases.v1.Question.UpdateQuestion;
 
@@ -7,7 +8,7 @@ public record UpdateQuestionRequest
     [MaxLength(100)]
     public string Title { get; set; }
 
-    [Range(1, 5)]
+    [Range(0, 100, ErrorMessage = "The Difficulty field is out of range ( 0 - 100 )")]
     public int? Difficulty { get; set; }
 
     [MaxLength(50)]

--- a/src/WebApi/WebApi/UseCases/v1/Question/UpdateQuestion/UpdateQuestionRequest.cs
+++ b/src/WebApi/WebApi/UseCases/v1/Question/UpdateQuestion/UpdateQuestionRequest.cs
@@ -8,7 +8,7 @@ public record UpdateQuestionRequest
     [MaxLength(100)]
     public string Title { get; set; }
 
-    [Range(1, 5)]
+    [Range(0, 100, ErrorMessage = "The Difficulty field is out of range ( 0 - 100 )")]
     public int? Difficulty { get; set; }
 
     [MaxLength(50)]

--- a/src/WebApi/WebApi/UseCases/v1/Question/UpdateQuestion/UpdateQuestionRequest.cs
+++ b/src/WebApi/WebApi/UseCases/v1/Question/UpdateQuestion/UpdateQuestionRequest.cs
@@ -8,7 +8,7 @@ public record UpdateQuestionRequest
     [MaxLength(100)]
     public string Title { get; set; }
 
-    [Range(0, 100, ErrorMessage = "The Difficulty field is out of range ( 0 - 100 )")]
+    [Range(1, 5)]
     public int? Difficulty { get; set; }
 
     [MaxLength(50)]


### PR DESCRIPTION
Added the necessary validation attributes to the Difficulty property

## Summary

Added  [Range] and [Required] attributes to the Difficulty properly  in :
*CreateQuestionRequest

Added [Range] attributes to the Difficulty properly  in :
*UpdateQuuestionRequest

Added a custume Validation Attribute to the Difficulties properly  in : 
*GetQuestionRequest

Note: For Difficulties properly in GetQuesttionRequest , i added an extension to the ValidationAtribute Class to be able to validate the range of an IEnumerable< int > Difficulties

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (non-breaking change to code and structure)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notes


I was wondering if the custume validation for  IEnumerable<int> Difficulties should maybe return all the questions for the difficulties that were correct, and just ignore the out of range ones, instead of what my implementation does ,which is return an error if one of the values in the IEnumerable is out oof range.

Also , for some reason when updating a question ,if one of the values is not provided in the put request the value is set to null , i was wondering is that was by choice .

If there is anything to change or modify just let me know , thanks in advance!


